### PR TITLE
Refresh workspace from merged trunk before SVN sync

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -128,6 +128,18 @@ jobs:
                   echo "PR #$PR did not merge within 10 minutes" >&2
                   exit 1
 
+            - name: Refresh workspace from merged trunk
+              if: success() && steps.pr.outputs.pull-request-number
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  # peter-evans/create-pull-request leaves the working tree at the pre-PR
+                  # state, and the merge happens on the remote. Pull the post-merge trunk
+                  # so the SVN sync below copies the actually-bumped readme.txt rather than
+                  # the workspace's stale copy.
+                  git fetch origin trunk
+                  git reset --hard origin/trunk
+
             - name: Sync readme to WordPress.org SVN
               if: success() && steps.pr.outputs.pull-request-number
               uses: 10up/action-wordpress-plugin-asset-update@stable


### PR DESCRIPTION
**Bug:** the cron workflow successfully bumps `readme.txt` and creates an audit-trail PR that auto-merges to `trunk`, but the inline SVN sync step exits `Nothing to deploy!` and WordPress.org stays on the old `Tested up to:` value.

**Cause:** `peter-evans/create-pull-request` doesn't modify the workflow's working tree — the change is committed to a separate branch and pushed. After the merge poll loop returns, `trunk` on GitHub has the bumped `readme.txt` but the workflow's local `$GITHUB_WORKSPACE` still holds the pre-bump readme. The 10up asset-update action then copies that stale workspace readme to SVN trunk, sees no diff against SVN, and exits clean.

**Fix:** between the merge step and the SVN sync, run `git fetch origin trunk && git reset --hard origin/trunk` so the workspace mirrors what was just merged. The SVN sync step then has the right content to publish.

Discovered by a manual smoke run on wpmu-network-site-users-dropdown: PR [#10](https://github.com/obenland/wpmu-network-site-users-dropdown/pull/10) was created and merged correctly (trunk readme.txt now at 6.9), but SVN trunk stayed at 6.4. Merging this PR via my user PAT will also fire the existing `push-asset-readme-update.yml` (still triggered by user-driven `push: branches: [trunk]`), which resyncs SVN to 6.9 in passing.