### PR TITLE
Set IGNORE_OTHER_FILES on asset/readme sync action

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -14,3 +14,4 @@ jobs:
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  IGNORE_OTHER_FILES: true


### PR DESCRIPTION
## Summary

The asset/readme sync workflow was running `10up/action-wordpress-plugin-asset-update` without `IGNORE_OTHER_FILES`. Without that env var, the action syncs every file at the repo root that isn't already in SVN — including source PHP, `composer.json`, `package.json`, etc. — into the SVN trunk on every `.wordpress-org/**` or `readme.txt` push.

That's wrong here: code is supposed to ship via `deploy.yml` at tag time. The asset/readme workflow should keep the SVN `assets/` directory and `readme.txt` in sync between releases — nothing else.

`IGNORE_OTHER_FILES: true` restricts the action to those two paths. Mirrors the setting already in place in `block-for-strava`, `wp-approve-user`, and `uploads-unleashed`.

## Test plan

- [ ] Workflow YAML parses cleanly (single-line `with`/`env` change).
- [ ] On the next `.wordpress-org/**` or `readme.txt` push, only those paths get synced to SVN — no source files leak through.