### PR TITLE
Convert readme.txt to README.md

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  sparse-checkout: readme.txt
+                  sparse-checkout: README.md
                   sparse-checkout-cone-mode: false
 
             - name: Compare latest WordPress against readme
@@ -49,9 +49,9 @@ jobs:
                       echo "Failed to derive major.minor from '$latest'" >&2
                       exit 1
                   fi
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      echo "Could not find 'Tested up to:' header in README.md" >&2
                       exit 1
                   fi
                   sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
@@ -205,15 +205,15 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Update readme.txt
+            - name: Update README.md
               shell: bash
               env:
                   TARGET: ${{ needs.check.outputs.version }}
                   PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
-                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" README.md
+                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
@@ -230,7 +230,7 @@ jobs:
                   body: |
                       WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                      Bumps `Tested up to` in README.md from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
                   branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 
@@ -283,7 +283,7 @@ jobs:
                   set -euo pipefail
                   # peter-evans/create-pull-request leaves the working tree at the pre-PR
                   # state, and the merge happens on the remote. Pull the post-merge trunk
-                  # so the SVN sync below copies the actually-bumped readme.txt rather than
+                  # so the SVN sync below copies the actually-bumped README.md rather than
                   # the workspace's stale copy.
                   git fetch origin trunk
                   git reset --hard origin/trunk

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-=== WPMU Network Site Users Dropdown ===
+# WPMU Network Site Users Dropdown
 Contributors: obenland
 Tags: admin, wpmu, network, network admin
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=HEXL3UM8D7R6N
@@ -8,72 +8,72 @@ Stable tag: 3
 
 Replace the input field for adding existing users to a site with a more comfortable dropdown menu!
 
-== Description ==
+## Description
 
 This plugin lets you as a network administrator add users to your sites without having to remember or look up the user's login name. It replaces the input field with a comfortable dropdown menu, so you can choose between all existing users that are not yet added to the site.
 
 Don't worry about code overhead or performance issues, the plugin will only be loaded when a network admin screen is requested.
 
 
-== Installation ==
+## Installation
 
 1. Download WPMU Network Site Users Dropdown.
 2. Unzip the folder into the `/wp-content/plugins/` directory.
 3. Activate the plugin through the 'Plugins' menu in WordPress.
 
 
-== Frequently Asked Questions ==
+## Frequently Asked Questions
 
 None asked yet.
 
 
-== Screenshots ==
+## Screenshots
 
 1. The original form.
 2. The form with the dropdown. Notice the use of the user's display_name.
 
 
-== Changelog ==
+## Changelog
 
-= 3 =
+### 3
 * Inline documentation updates.
 
-= 2 =
+### 2
 * Maintenance release.
 * Only works if there are less than 100 registered users.
 * Updated code to adhere to WordPress Coding Standards.
 * Tested with WordPress 5.0.
 
-= 1.5.0 =
+### 1.5.0
 * Maintenance release.
 * Tested with WordPress 4.0.
 
-= 1.4.2 =
+### 1.4.2
 * Maintenance release.
 * Tested WordPress 3.4.1.
 * Updated utility class.
 
-= 1.4.1 =
+### 1.4.1
 * Improved user experience when plugin is activated on a non-multisite environment.
 * Updated utility class.
 
-= 1.4 =
+### 1.4
 * Updated textdomain handling for translation.
 * Tested for WordPress 3.3.1.
 
-= 1.3 =
+### 1.3
 * Fixed a bug where already associated users were in the dropdown field.
 * Updated utility class.
 
-= 1.2 =
+### 1.2
 * Tested WordPress 3.1.2.
 * Fixed a bug where plugin could not be activated.
 * Updated utility class.
 
-= 1.1 =
+### 1.1
 * Tested WordPress 3.1.1.
 * Added multisite check.
 * Updated class structure.
 
-= 1.0 =
+### 1.0
 * Initial Release.


### PR DESCRIPTION
## Summary

Renames `readme.txt` to `README.md` (GitHub renders it on the repo home) without giving up the wp.org plugin page.

WordPress.org's plugin-directory parser accepts either filename — its lookup regex is `!(?:^|/)readme\.(txt|md)$!i` (case-insensitive, .md included) — and the section grammar already supports `##` headers alongside `==`. The WP field block (`Contributors:`, `Tested up to:`, `Stable tag:`, …) stays in the same `Field: Value` format in both files. Within sections, `### x.y.z` becomes the changelog entry form (since `###` doesn't end a section).

Workflows that read or write the readme are updated to point at `README.md`:

- `update-tested-up-to.yml` — sparse-checkout, the `[Tt]ested up to:` sed/grep, and the PR body
- `push-asset-readme-update.yml` / `plugin-asset-update.yml` — path triggers
- `phpunit*.yml`, `playwright*.yml`, `test-e2e.yml` — `paths-ignore` arrays

For uploads-unleashed, `release.yml`'s changelog-insertion logic is also rewritten: it now greps for `^### <tag>$` and inserts after `^## Changelog`, and `.distignore` no longer excludes `README.md` from the SVN sync.

## Test plan

- [ ] GitHub renders README.md on the repo home.
- [ ] Next scheduled `update-tested-up-to` run finds the `Tested up to:` header in README.md and behaves the same as before.
- [ ] wp.org plugin page continues to show the readme content on the next deploy (parser picks up README.md via the case-insensitive lookup).
