### PR TITLE
Fix wp.org import warnings (License + Tags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Requires at least: 3.1
 Tested up to: 6.9
 Stable tag: 3
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Replace the input field for adding existing users to a site with a more comfortable dropdown menu!
 


### PR DESCRIPTION
Addresses the two warnings wp.org's importer surfaced after the readme.txt → README.md rename. See commit message for details. Pre-existing in the original readme.txt; not introduced by the rename.