### PR TITLE
Bump Tested up to 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: obenland
 Tags: admin, wpmu, network, network admin
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=HEXL3UM8D7R6N
 Requires at least: 3.1
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WordPress 7.0 is the latest stable release.

Bumps `Tested up to` in README.md from 6.9 to 7.0 (major.minor of 7.0).